### PR TITLE
Fix NPE when no ports have been forwarded

### DIFF
--- a/src/plugins/UPnP/UPnP.java
+++ b/src/plugins/UPnP/UPnP.java
@@ -221,7 +221,9 @@ public class UPnP extends ControlPoint
         Set ports = new HashSet<ForwardPort>();
 
         synchronized (lock) {
-            ports.addAll(portsToForward);
+            if (portsToForward != null) {
+                ports.addAll(portsToForward);
+            }
         }
 
         if (ports.isEmpty()) {


### PR DESCRIPTION
This prevents a NullPointerException to be thrown when a UPnP device is found, but no ports have been forwarded yet (whether this condition itself is a bug, a race condition or expected behaviour, I can't tell).

This should fix the part of [bug 0006634](https://bugs.freenetproject.org/view.php?id=6634) that has not yet been addressed by #3.
The NPE is thrown in a separate thread, preventing the SSDP socket from being instantiated, then triggering the bug now solved by #3.