### PR TITLE
Fix connection reset on case sensitive Host HTTP header name

### DIFF
--- a/src/plugins/UPnP/org/cybergarage/http/HTTP.java
+++ b/src/plugins/UPnP/org/cybergarage/http/HTTP.java
@@ -40,7 +40,7 @@ public class HTTP {
     ////////////////////////////////////////////////
     // Constants
     ////////////////////////////////////////////////
-    public static final String HOST = "HOST";
+    public static final String HOST = "Host";
     public static final String VERSION = "1.1";
     public static final String VERSION_10 = "1.0";
     public static final String VERSION_11 = "1.1";


### PR DESCRIPTION
Some routers do not conform to RFC2616 section 4.2 regarding case-
insensitivity of HTTP header names, and may reset the connection if an
unexpected case is used. Cybergarage UPnP uses 'HOST' as the header
name, causing the routers expecting the far more common 'Host' to fail.

The Technicolor TC7210, the newest cable modem distributed by the Dutch
internet service provider Ziggo, is one of the affected models.

RFC2616 warns for this problem of incomplete implementations:
> Applications ought to follow "common form", where one is known or
> indicated, when generating HTTP constructs, since there might exist
> some implementations that fail to accept anything.

Since 'Host' is the common form, use that instead of 'HOST'.

I recently acquired one of the affected routers mentioned above, and noticed that UPnP was no longer working. The plugin works correctly after applying this fix. This might also explain other cases of reset connections reported in the recent past on the bug tracker.